### PR TITLE
Solved the warnings

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -132,9 +132,9 @@ class MTableBody extends React.Component {
     if (this.props.options.paging) {
       emptyRowCount = this.props.pageSize - renderData.length;
     }
-    
+
     return (
-      <TableBody ref={this.props.innerRef}>
+      <TableBody ref={this.props.provided?.innerRef}>
         {this.props.options.filtering &&
           <this.props.components.FilterRow
             columns={this.props.columns.filter(columnDef => !columnDef.hidden)}
@@ -193,6 +193,7 @@ class MTableBody extends React.Component {
           />
         }
         {this.renderEmpty(emptyRowCount, renderData)}
+        {this.props.provided.placeholder}
       </TableBody>
     );
   }
@@ -238,7 +239,7 @@ MTableBody.propTypes = {
   onRowClick: PropTypes.func,
   onEditingCanceled: PropTypes.func,
   onEditingApproved: PropTypes.func,
-  innerRef: PropTypes.any,
+  provided: PropTypes.object,
 };
 
 export default MTableBody;

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -112,7 +112,7 @@ export const defaultProps = {
     defaultExpanded: false,
     detailPanelColumnAlignment: 'left',
     thirdSortClick: true,
-    overflowY: 'auto',
+    overflowY: 'initial',
   },
   localization: {
     grouping: {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -611,7 +611,7 @@ export default class MaterialTable extends React.Component {
         <Droppable isDropDisabled={!this.props.options.draggableRows} droppableId={this.draggableRowsIdentifier}>
           {(provided, snapshot) => (
             <props.components.Body
-              innerRef={provided.innerRef}
+              provided={provided}
               actions={props.actions}
               components={props.components}
               icons={props.icons}
@@ -743,7 +743,7 @@ export default class MaterialTable extends React.Component {
                         </div> : null
                       }
 
-                      <div  >
+                      <div>
                         {table}
                       </div>
 


### PR DESCRIPTION
## Related Issue
[comment on PR master](https://github.com/mbrn/material-table/pull/1995#issuecomment-640032290
)
## Description
Resolved the warnings.
Added the while provided object as props to Body instead of only innerRef so the mandatory placeholder could be set.
Made overflow-Y default initial because of this issue of [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd/issues/131)

## Impacted Areas in Application
Everything still works but without warnings in the console.

## Additional Notes
overflow-Y can only be 'initial' when we make use of draggable rows if we don't want warnings in the console in development.